### PR TITLE
Remove single quotes from node name

### DIFF
--- a/ZenPacks/zenoss/RabbitMQ/RabbitMQComponent.py
+++ b/ZenPacks/zenoss/RabbitMQ/RabbitMQComponent.py
@@ -36,5 +36,8 @@ class RabbitMQComponent(DeviceComponent, ManagedEntity):
             },),
         },)
 
+    # Query for events by id instead of name.
+    event_key = "ComponentId"
+
     # Commands are run via SSH and should not be specified absolutely.
     zCommandPath = ''


### PR DESCRIPTION
The version of RabbitMQ I'm running surrounds the `Status of node` text in single quotes, this fixed the issue for me and should be backwards compatible.

```
Status of node 'rabbit@dev' ...
[{pid,6382},
 {running_applications,
     [{rabbitmq_management_visualiser,"RabbitMQ Visualiser","2.6.1"},
      {rabbitmq_management,"RabbitMQ Management Console","2.6.1.jquery-fix"},
      {rabbitmq_mochiweb,"RabbitMQ Mochiweb Embedding","2.6.1"},
      {webmachine,"webmachine","1.7.0-rmq2.6.1-hg0c4b60a"},
      {amqp_client,"RabbitMQ AMQP Client","2.6.1"},
      {rabbitmq_management_agent,"RabbitMQ Management Agent","2.6.1"},
      {mochiweb,"MochiMedia Web Server","1.3-rmq2.6.1-git9a53dbd"},
      {inets,"INETS  CXC 138 49","5.6"},
      {rabbitmq_stomp,"Embedded Rabbit Stomp Adapter","2.6.1"},
      {rabbit,"RabbitMQ","2.6.1"},
      {mnesia,"MNESIA  CXC 138 12","4.4.19"},
      {os_mon,"CPO  CXC 138 46","2.2.6"},
      {sasl,"SASL  CXC 138 11","2.1.9.4"},
      {stdlib,"ERTS  CXC 138 10","1.17.4"},
      {kernel,"ERTS  CXC 138 10","2.14.4"}]},
 {os,{unix,linux}},
 {erlang_version,
     "Erlang R14B03 (erts-5.8.4) [source] [64-bit] [rq:1] [async-threads:30] [kernel-poll:true]\n"},
 {memory,
     [{total,69573600},
      {processes,12329072},
      {processes_used,12285320},
      {system,57244528},
      {atom,1364153},
      {atom_used,1355719},
      {binary,147768},
      {code,14518794},
      {ets,1199472}]}]
...done.
```
