### PR TITLE
Fix bug where exchange_string has more than 5 parts resulting in error

### DIFF
--- a/ZenPacks/zenoss/RabbitMQ/modeler/plugins/zenoss/ssh/RabbitMQ.py
+++ b/ZenPacks/zenoss/RabbitMQ/modeler/plugins/zenoss/ssh/RabbitMQ.py
@@ -136,8 +136,14 @@ class RabbitMQ(CommandPlugin):
             if not exchange_string.strip():
                 continue
 
-            name, exchange_type, durable, auto_delete, arguments = \
-                re.split(r'\s+', exchange_string)
+            try:
+                name, exchange_type, durable, auto_delete, arguments = \
+                    re.split(r'\s+', exchange_string)
+            except ValueError:
+                LOG.info('This line has an invalid number of values: %s. Trying to fix it', exchange_string)
+                parts = re.split(r'\s+', exchange_string)
+                name = ' '.join(parts[0:(len(parts)-4)])
+		exchange_type, durable, auto_delete, arguments = parts[-4:]
 
             if not name:
                 name = 'amq.default'


### PR DESCRIPTION
In my case I had a variable exchange_string in exchanges_string that had this value:

"All Messages fanout true false []"

As this string gets split based on whitespace this results in 6 parts which then are assigned to only 5 variables which makes the code crash.
