### PR TITLE
replace ':' with '_' in queues so that point.component can find match in queues

### DIFF
--- a/ZenPacks/zenoss/RabbitMQ/parsers/RabbitMQCTL.py
+++ b/ZenPacks/zenoss/RabbitMQ/parsers/RabbitMQCTL.py
@@ -17,6 +17,7 @@ import os
 import re
 import tempfile
 import time
+import string
 
 from Products.ZenRRD.CommandParser import CommandParser
 
@@ -212,7 +213,8 @@ class RabbitMQCTL(CommandParser):
             if len(fields) != 6:
                 continue
 
-            queues[fields[0]] = dict(
+            translation_table = string.maketrans(':', '_')
+            queues[fields[0].translate(translation_table)] = dict(
                 ready=int(fields[1]),
                 unacknowledged=int(fields[2]),
                 messages=int(fields[3]),


### PR DESCRIPTION

It is legal for RabbitMQ to have ':' in queue names. However, zenoss will replace ':' in queue name with '_', and this causes this ZP to not generate RRD files for the queues with ':' in names. This fix addresses this issue.
