### PR TITLE
Add Federation Plugin support

### DIFF
--- a/ZenPacks/zenoss/RabbitMQ/RabbitMQExchange.py
+++ b/ZenPacks/zenoss/RabbitMQ/RabbitMQExchange.py
@@ -23,11 +23,13 @@ class RabbitMQExchange(RabbitMQComponent):
     durable = None
     auto_delete = None
     arguments = None
+    federated = None
 
     _properties = RabbitMQComponent._properties + (
         {'id': 'exchange_type', 'type': 'string', 'mode': 'w'},
         {'id': 'durable', 'type': 'boolean', 'mode': 'w'},
         {'id': 'auto_delete', 'type': 'boolean', 'mode': 'w'},
+        {'id': 'federated', 'type': 'boolean', 'mode': 'w'},
         {'id': 'arguments', 'type': 'string', 'mode': 'w'},
         )
 

--- a/ZenPacks/zenoss/RabbitMQ/RabbitMQQueue.py
+++ b/ZenPacks/zenoss/RabbitMQ/RabbitMQQueue.py
@@ -23,6 +23,7 @@ class RabbitMQQueue(RabbitMQComponent):
     durable = None
     auto_delete = None
     arguments = None
+    federated = None
 
     # Managed attributes.
     threshold_messages_max = None
@@ -31,6 +32,7 @@ class RabbitMQQueue(RabbitMQComponent):
         {'id': 'durable', 'type': 'boolean', 'mode': 'w'},
         {'id': 'auto_delete', 'type': 'boolean', 'mode': 'w'},
         {'id': 'arguments', 'type': 'string', 'mode': 'w'},
+        {'id': 'federated', 'type': 'boolean', 'mode': 'w'},
         {'id': 'threshold_messages_max', 'type': 'int', 'mode': 'w'},
         )
 

--- a/ZenPacks/zenoss/RabbitMQ/browser/resources/js/RabbitMQDevice.js
+++ b/ZenPacks/zenoss/RabbitMQ/browser/resources/js/RabbitMQDevice.js
@@ -260,6 +260,7 @@ ZC.RabbitMQExchangePanel = Ext.extend(ZC.RabbitMQComponentGridPanel, {
                 {name: 'exchange_type'},
                 {name: 'durable'},
                 {name: 'auto_delete'},
+                {name: 'federated'},
                 {name: 'monitor'},
                 {name: 'monitored'},
                 {name: 'locking'}
@@ -310,6 +311,13 @@ ZC.RabbitMQExchangePanel = Ext.extend(ZC.RabbitMQComponentGridPanel, {
                 sortable: true,
                 width: 70
             },{
+                id: 'federated',
+                dataIndex: 'federated',
+                header: _t('Federated'),
+                renderer: Zenoss.render.checkbox,
+                sortable: true,
+                width: 70
+            },{
                 id: 'monitored',
                 dataIndex: 'monitored',
                 header: _t('Monitored'),
@@ -344,6 +352,7 @@ ZC.RabbitMQQueuePanel = Ext.extend(ZC.RabbitMQComponentGridPanel, {
                 {name: 'rabbitmq_vhost'},
                 {name: 'durable'},
                 {name: 'auto_delete'},
+                {name: 'federated'},
                 {name: 'threshold_messages_max'},
                 {name: 'monitor'},
                 {name: 'monitored'},
@@ -385,6 +394,13 @@ ZC.RabbitMQQueuePanel = Ext.extend(ZC.RabbitMQComponentGridPanel, {
                 id: 'auto_delete',
                 dataIndex: 'auto_delete',
                 header: _t('Auto-Delete'),
+                renderer: Zenoss.render.checkbox,
+                sortable: true,
+                width: 70
+            },{
+                id: 'federated',
+                dataIndex: 'federated',
+                header: _t('Federated'),
                 renderer: Zenoss.render.checkbox,
                 sortable: true,
                 width: 70

--- a/ZenPacks/zenoss/RabbitMQ/info.py
+++ b/ZenPacks/zenoss/RabbitMQ/info.py
@@ -70,6 +70,7 @@ class RabbitMQExchangeInfo(ComponentInfo):
     exchange_type = ProxyProperty('exchange_type')
     durable = ProxyProperty('durable')
     auto_delete = ProxyProperty('auto_delete')
+    federated = ProxyProperty('federated')
     arguments = ProxyProperty('arguments')
 
     @property
@@ -88,6 +89,7 @@ class RabbitMQQueueInfo(ComponentInfo):
 
     durable = ProxyProperty('durable')
     auto_delete = ProxyProperty('auto_delete')
+    federated = ProxyProperty('federated')
     arguments = ProxyProperty('arguments')
 
     @property

--- a/ZenPacks/zenoss/RabbitMQ/interfaces.py
+++ b/ZenPacks/zenoss/RabbitMQ/interfaces.py
@@ -52,6 +52,7 @@ class IRabbitMQExchangeInfo(IComponentInfo):
     exchange_type = SingleLineText(title=_t(u"Type"))
     durable = schema.Bool(title=_t("Durable"))
     auto_delete = schema.Bool(title=_t("Auto-Delete"))
+    federated = schema.Bool(title=_t("Federated"))
     arguments = SingleLineText(title=_t(u"Arguments"))
 
 
@@ -60,6 +61,7 @@ class IRabbitMQQueueInfo(IComponentInfo):
     rabbitmq_vhost = schema.Entity(title=_t(u"VHost"))
     durable = schema.Bool(title=_t("Durable"))
     auto_delete = schema.Bool(title=_t("Auto-Delete"))
+    federated = schema.Bool(title=_t("Federated"))
     arguments = SingleLineText(title=_t(u"Arguments"))
 
     threshold_messages_max = schema.Int(

--- a/ZenPacks/zenoss/RabbitMQ/modeler/plugins/zenoss/ssh/RabbitMQ.py
+++ b/ZenPacks/zenoss/RabbitMQ/modeler/plugins/zenoss/ssh/RabbitMQ.py
@@ -151,6 +151,9 @@ class RabbitMQ(CommandPlugin):
                                       split_exchange[8])
                     name, exchange_type, durable, auto_delete, arguments = \
                         re.split(r'\s+', exchange_string.strip())
+                else:
+                    LOG.error("Unhandled Federated Exchange String")
+                    continue
             elif exchange_string.startswith(('direct','topic','headers','fanout')):
                 exchange_string = "amq.default " + exchange_string
                 name, exchange_type, durable, auto_delete, arguments = \
@@ -195,12 +198,16 @@ class RabbitMQ(CommandPlugin):
             if queue_string.startswith('federation'):
                 federated = True
                 split_queue = re.split(r'\s+', queue_string.strip())
-                queue_string = (split_queue[1] + " " +
-                                split_queue[4] + " " +
-                                split_queue[5] + " " +
-                                split_queue[6])
-                name, durable, auto_delete, arguments = \
-                    re.split(r'\s+', queue_string.strip())
+                if len(split_queue) == 7:
+                    queue_string = (split_queue[1] + " " +
+                                    split_queue[4] + " " +
+                                    split_queue[5] + " " +
+                                    split_queue[6])
+                    name, durable, auto_delete, arguments = \
+                        re.split(r'\s+', queue_string.strip())
+                else:
+                    LOG.error("Unhandled Federated Queue String")
+                    continue
             elif queue_string.startswith(('direct','topic','headers','fanout')):
                 queue_string = "amq.default " + queue_string
                 name, durable, auto_delete, arguments = \


### PR DESCRIPTION
The output format for federated queues and exchanges differs from
normal ones, so the modeler has been updated to handle that format.
Some additional safety has been added, such as handling the default '/'
exchange better.

There is also now a bool property on queues and exchanges to indicate whether
they are federated or not.

Fixes ZEN-20898